### PR TITLE
fix: 修复 Windows 上 OpenClaw CLI 检测逻辑

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clawpanel",
-  "version": "0.7.2",
+  "version": "0.9.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clawpanel",
-      "version": "0.7.2",
+      "version": "0.9.5",
       "license": "AGPL-3.0",
       "dependencies": {
         "@tauri-apps/api": "^2.5.0",

--- a/scripts/dev-api.js
+++ b/scripts/dev-api.js
@@ -1532,7 +1532,17 @@ const handlers = {
       if (isMac) {
         cliInstalled = fs.existsSync('/opt/homebrew/bin/openclaw') || fs.existsSync('/usr/local/bin/openclaw')
       } else if (isWindows) {
-        try { cliInstalled = fs.existsSync(path.join(process.env.APPDATA || '', 'npm', 'openclaw.cmd')) }
+        try {
+          // 检查多个可能的安装位置
+          const paths = [
+            path.join(process.env.APPDATA || '', 'npm', 'openclaw.cmd'),
+            path.join(process.env.APPDATA || '', 'npm', 'openclaw'),
+            path.join(process.env.ProgramFiles || '', 'nodejs', 'openclaw.cmd'),
+            path.join(process.env.ProgramFiles || '', 'nodejs', 'openclaw'),
+            'C:\\WINDOWS\\system32\\openclaw',
+          ]
+          cliInstalled = paths.some(p => fs.existsSync(p))
+        }
         catch { cliInstalled = false }
       } else {
         cliInstalled = !!findOpenclawBin()


### PR DESCRIPTION
- 增加多个可能的安装路径检测

- 解决用户安装 OpenClaw 后仍被提示需要安装的问题

## 变更描述

修复 Windows 系统上 OpenClaw CLI 检测逻辑不完善的问题。

当前检测只检查 `%APPDATA%\npm\openclaw.cmd` 一个路径，但用户的 OpenClaw 可能安装在不同位置（如 `C:\WINDOWS\system32\openclaw` 或其他 npm 全局安装路径），导致已安装 OpenClaw 的用户仍被提示需要安装。

本次修改增加了多个可能的安装路径检测：
- `%APPDATA%\npm\openclaw.cmd`
- `%APPDATA%\npm\openclaw`
- `%ProgramFiles%\nodejs\openclaw.cmd`
- `%ProgramFiles%\nodejs\openclaw`
- `C:\WINDOWS\system32\openclaw`

## 变更类型

- [ ] 新功能 (feat)
- [x] Bug 修复 (fix)
- [ ] 代码重构 (refactor)
- [ ] 样式调整 (style)
- [ ] 性能优化 (perf)
- [ ] 文档更新 (docs)
- [ ] 构建/CI 配置 (ci/build)
- [ ] 其他 (chore)

## 测试清单

- [x] 本地运行 `npm run build` 前端构建通过
- [ ] 本地运行 `cargo check` Rust 编译通过
- [ ] 在 macOS 上测试通过
- [x] 在 Windows 上测试通过
- [ ] 在 Linux 上测试通过
- [ ] 新功能已添加对应测试
- [ ] 所有现有测试通过

## 相关 Issue

无

## 截图

不涉及 UI 变更，无需截图。
