### PR TITLE
feat: improve dashboard, skills, sidebar, and cloudflared settings

### DIFF
--- a/src/components/sidebar.js
+++ b/src/components/sidebar.js
@@ -74,9 +74,9 @@ const NAV_ITEMS_SETUP = [
 
 const ICONS = {
   setup: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M4 19.5A2.5 2.5 0 016.5 17H20"/><path d="M6.5 2H20v20H6.5A2.5 2.5 0 014 19.5v-15A2.5 2.5 0 016.5 2z"/></svg>',
-  dashboard: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><rect x="14" y="14" width="7" height="7" rx="1"/></svg>',
+  dashboard: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="8" height="8" rx="2"/><rect x="13" y="3" width="8" height="5" rx="2"/><rect x="13" y="10" width="8" height="11" rx="2"/><rect x="3" y="13" width="8" height="8" rx="2"/></svg>',
   chat: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 15a2 2 0 01-2 2H7l-4 4V5a2 2 0 012-2h14a2 2 0 012 2z"/></svg>',
-  services: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="3"/><path d="M12 1v4M12 19v4M4.22 4.22l2.83 2.83M16.95 16.95l2.83 2.83M1 12h4M19 12h4M4.22 19.78l2.83-2.83M16.95 7.05l2.83-2.83"/></svg>',
+  services: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="4" width="18" height="6" rx="2"/><rect x="3" y="14" width="18" height="6" rx="2"/><path d="M7 7h.01M7 17h.01M11 7h6M11 17h6"/></svg>',
   logs: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z"/><path d="M14 2v6h6"/><line x1="16" y1="13" x2="8" y2="13"/><line x1="16" y1="17" x2="8" y2="17"/></svg>',
   models: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 16V8a2 2 0 00-1-1.73l-7-4a2 2 0 00-2 0l-7 4A2 2 0 003 8v8a2 2 0 001 1.73l7 4a2 2 0 002 0l7-4A2 2 0 0021 16z"/><path d="M3.27 6.96L12 12.01l8.73-5.05M12 22.08V12"/></svg>',
   agents: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M17 21v-2a4 4 0 00-4-4H5a4 4 0 00-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 00-3-3.87M16 3.13a4 4 0 010 7.75"/></svg>',
@@ -86,7 +86,7 @@ const ICONS = {
   about: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><line x1="12" y1="16" x2="12" y2="12"/><line x1="12" y1="8" x2="12.01" y2="8"/></svg>',
   assistant: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M9.813 15.904L9 18.75l-.813-2.846a4.5 4.5 0 00-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 003.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 003.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 00-3.09 3.09z"/><path d="M18.259 8.715L18 9.75l-.259-1.035a3.375 3.375 0 00-2.455-2.456L14.25 6l1.036-.259a3.375 3.375 0 002.455-2.456L18 2.25l.259 1.035a3.375 3.375 0 002.456 2.456L21.75 6l-1.035.259a3.375 3.375 0 00-2.456 2.456z"/></svg>',
   security: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="11" width="18" height="11" rx="2" ry="2"/><path d="M7 11V7a5 5 0 0110 0v4"/></svg>',
-  skills: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M14.7 6.3a1 1 0 000 1.4l1.6 1.6a1 1 0 001.4 0l3.77-3.77a6 6 0 01-7.94 7.94l-6.91 6.91a2.12 2.12 0 01-3-3l6.91-6.91a6 6 0 017.94-7.94l-3.76 3.76z"/></svg>',
+  skills: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M6 8a2 2 0 012-2h3l2-2 5 5-2 2v3a2 2 0 01-2 2h-2l-4.5 4.5a1.5 1.5 0 01-2.12-2.12L10 14H8a2 2 0 01-2-2V8z"/><path d="M14 6l4 4"/></svg>',
   channels: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M22 12h-4l-3 9L9 3l-3 9H2"/></svg>',
   clock: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg>',
   'bar-chart': '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="12" y1="20" x2="12" y2="10"/><line x1="18" y1="20" x2="18" y2="4"/><line x1="6" y1="20" x2="6" y2="16"/></svg>',
@@ -109,9 +109,29 @@ function _checkMultiInstances(el) {
 }
 
 const LS_SIDEBAR_COLLAPSED = 'clawpanel_sidebar_collapsed'
+const LS_SIDEBAR_GROUPS = 'clawpanel_sidebar_groups'
 
 function _isDesktopSidebarCollapsed() {
   try { return localStorage.getItem(LS_SIDEBAR_COLLAPSED) === '1' } catch { return false }
+}
+
+function _getSidebarGroupState() {
+  try {
+    return JSON.parse(localStorage.getItem(LS_SIDEBAR_GROUPS) || '{}') || {}
+  } catch {
+    return {}
+  }
+}
+
+function _isSidebarGroupOpen(key) {
+  const state = _getSidebarGroupState()
+  return state[key] !== false
+}
+
+function _setSidebarGroupOpen(key, open) {
+  const state = _getSidebarGroupState()
+  state[key] = !!open
+  try { localStorage.setItem(LS_SIDEBAR_GROUPS, JSON.stringify(state)) } catch {}
 }
 
 function _setDesktopSidebarCollapsed(collapsed) {
@@ -155,8 +175,16 @@ export function renderSidebar(el) {
   const navItems = isOpenclawReady() ? NAV_ITEMS_FULL : NAV_ITEMS_SETUP
 
   for (const section of navItems) {
-    html += `<div class="nav-section">
-      <div class="nav-section-title">${section.section}</div>`
+    const sectionKey = section.section || `section-${section.items.map(item => item.route).join('|')}`
+    const expanded = section.section ? _isSidebarGroupOpen(sectionKey) : true
+    html += `<div class="nav-section${expanded ? ' expanded' : ' collapsed'}" data-section="${_escSidebar(sectionKey)}">`
+    if (section.section) {
+      html += `<button class="nav-section-toggle" type="button" data-section-toggle="${_escSidebar(sectionKey)}">
+        <span class="nav-section-title">${section.section}</span>
+        <span class="nav-section-chevron">${expanded ? '−' : '+'}</span>
+      </button>`
+    }
+    html += `<div class="nav-section-items"${expanded ? '' : ' style="display:none"'}>`
 
     for (const item of section.items) {
       const active = current === item.route ? ' active' : ''
@@ -165,7 +193,7 @@ export function renderSidebar(el) {
         <span>${item.label}</span>
       </div>`
     }
-    html += '</div>'
+    html += '</div></div>'
   }
 
   html += '</nav>'
@@ -200,6 +228,22 @@ export function renderSidebar(el) {
   if (!_delegated) {
     _delegated = true
     el.addEventListener('click', (e) => {
+      const sectionToggle = e.target.closest('[data-section-toggle]')
+      if (sectionToggle) {
+        const key = sectionToggle.dataset.sectionToggle
+        const sectionEl = e.target.closest('.nav-section[data-section]')
+        const itemsEl = sectionEl?.querySelector('.nav-section-items')
+        const nextOpen = sectionEl?.classList.contains('collapsed')
+        if (sectionEl) {
+          sectionEl.classList.toggle('expanded', !!nextOpen)
+          sectionEl.classList.toggle('collapsed', !nextOpen)
+        }
+        if (itemsEl) itemsEl.style.display = nextOpen ? '' : 'none'
+        const chevron = sectionToggle.querySelector('.nav-section-chevron')
+        if (chevron) chevron.textContent = nextOpen ? '−' : '+'
+        if (key) _setSidebarGroupOpen(key, !!nextOpen)
+        return
+      }
       // 导航点击
       const navItem = e.target.closest('.nav-item[data-route]')
       if (navItem) {

--- a/src/lib/skills-catalog.js
+++ b/src/lib/skills-catalog.js
@@ -1,0 +1,64 @@
+import { api } from './tauri-api.js'
+
+const SKILLS_CACHE_TTL_MS = 20_000
+
+let _skillsCache = {
+  data: null,
+  expiresAt: 0,
+  pending: null,
+}
+
+function normalizeSkillsData(data) {
+  return {
+    ...data,
+    skills: Array.isArray(data?.skills) ? data.skills : [],
+  }
+}
+
+export function summarizeSkillsCatalog(data) {
+  const skills = Array.isArray(data?.skills) ? data.skills : []
+  const eligible = skills.filter(s => s.eligible && !s.disabled)
+  const missing = skills.filter(s => !s.eligible && !s.disabled && !s.blockedByAllowlist)
+  const disabled = skills.filter(s => s.disabled)
+  const blocked = skills.filter(s => s.blockedByAllowlist && !s.disabled)
+  return {
+    total: skills.length,
+    eligible: eligible.length,
+    missing: missing.length,
+    disabled: disabled.length,
+    blocked: blocked.length,
+  }
+}
+
+export function getCachedSkillsCatalog() {
+  if (!_skillsCache.data) return null
+  if (Date.now() > _skillsCache.expiresAt) return null
+  return _skillsCache.data
+}
+
+export function invalidateSkillsCatalog() {
+  _skillsCache.expiresAt = 0
+}
+
+export async function loadSkillsCatalog(options = {}) {
+  const force = !!options.force
+  const now = Date.now()
+  if (!force && _skillsCache.data && now <= _skillsCache.expiresAt) {
+    return _skillsCache.data
+  }
+  if (!force && _skillsCache.pending) {
+    return _skillsCache.pending
+  }
+  const request = api.skillsList()
+    .then(normalizeSkillsData)
+    .then(data => {
+      _skillsCache.data = data
+      _skillsCache.expiresAt = Date.now() + SKILLS_CACHE_TTL_MS
+      return data
+    })
+    .finally(() => {
+      if (_skillsCache.pending === request) _skillsCache.pending = null
+    })
+  _skillsCache.pending = request
+  return request
+}

--- a/src/pages/dashboard.js
+++ b/src/pages/dashboard.js
@@ -262,7 +262,7 @@ function renderOverview(page, services, skillsData, backups, config, agents, sta
           <div class="overview-card-body">
             <div class="overview-card-title">Skills</div>
             <div class="overview-card-value">${skillSummary.total} 个</div>
-            <div class="overview-card-meta">${skillSummary.eligible} 可用 · ${skillSummary.missing} 缺依赖</div>
+            <div class="overview-card-meta">${skillSummary.eligible} 可用 · ${skillSummary.missing + skillSummary.blocked} 待处理 · ${skillSummary.disabled} 已禁用</div>
           </div>
         </div>
 

--- a/src/pages/dashboard.js
+++ b/src/pages/dashboard.js
@@ -4,6 +4,7 @@
 import { api } from '../lib/tauri-api.js'
 import { toast } from '../components/toast.js'
 import { onGatewayChange } from '../lib/app-state.js'
+import { loadSkillsCatalog, summarizeSkillsCatalog } from '../lib/skills-catalog.js'
 import { navigate } from '../router.js'
 
 let _unsubGw = null
@@ -80,7 +81,7 @@ async function loadDashboardData(page, fullRefresh = false) {
   ]), 15000)
   const secondaryP = withTimeout(Promise.allSettled([
     api.listAgents(),
-    api.readMcpConfig(),
+    loadSkillsCatalog({ force: fullRefresh }),
     api.listBackups(),
     // getStatusSummary 是最重的调用（spawn openclaw status --json），只在首次加载时调用
     (!_dashboardInitialized || fullRefresh) ? api.getStatusSummary() : Promise.resolve(null),
@@ -122,15 +123,15 @@ async function loadDashboardData(page, fullRefresh = false) {
 
   renderStatCards(page, services, version, [], config)
 
-  // 第二波：Agent、MCP、备份 → 更新卡片 + 渲染总览
-  const [agentsRes, mcpRes, backupsRes, statusRes] = await secondaryP
+  // 第二波：Agent、Skills、备份 → 更新卡片 + 渲染总览
+  const [agentsRes, skillsRes, backupsRes, statusRes] = await secondaryP
   const agents = agentsRes.status === 'fulfilled' ? agentsRes.value : []
-  const mcpConfig = mcpRes.status === 'fulfilled' ? mcpRes.value : null
+  const skillsData = skillsRes.status === 'fulfilled' ? skillsRes.value : null
   const backups = backupsRes.status === 'fulfilled' ? backupsRes.value : []
   const statusSummary = statusRes.status === 'fulfilled' ? statusRes.value : null
 
   renderStatCards(page, services, version, agents, config)
-  renderOverview(page, services, mcpConfig, backups, config, agents, statusSummary)
+  renderOverview(page, services, skillsData, backups, config, agents, statusSummary)
 
   // 第三波：日志（最低优先级）
   const logs = await logsP
@@ -199,10 +200,11 @@ function renderStatCards(page, services, version, agents, config) {
   `
 }
 
-function renderOverview(page, services, mcpConfig, backups, config, agents, statusSummary) {
+function renderOverview(page, services, skillsData, backups, config, agents, statusSummary) {
+  services = Array.isArray(services) ? services : []
   const containerEl = page.querySelector('#dashboard-overview-container')
   const gw = services.find(s => s.label === 'ai.openclaw.gateway')
-  const mcpCount = mcpConfig?.mcpServers ? Object.keys(mcpConfig.mcpServers).length : 0
+  const skillSummary = summarizeSkillsCatalog(skillsData)
 
   const formatDate = (timestamp) => {
     if (!timestamp) return '——'
@@ -255,12 +257,12 @@ function renderOverview(page, services, mcpConfig, backups, config, agents, stat
 
         <div class="overview-card" data-nav="/skills">
           <div class="overview-card-icon" style="color:var(--warning)">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="20" height="20"><polygon points="12 2 2 7 12 12 22 7 12 2"/><polyline points="2 17 12 22 22 17"/><polyline points="2 12 12 17 22 12"/></svg>
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="20" height="20"><path d="M14.7 6.3a1 1 0 000 1.4l1.6 1.6a1 1 0 001.4 0l3.77-3.77a6 6 0 01-7.94 7.94l-6.91 6.91a2.12 2.12 0 01-3-3l6.91-6.91a6 6 0 017.94-7.94l-3.76 3.76z"/></svg>
           </div>
           <div class="overview-card-body">
-            <div class="overview-card-title">MCP 工具</div>
-            <div class="overview-card-value">${mcpCount} 个</div>
-            <div class="overview-card-meta">已挂载扩展</div>
+            <div class="overview-card-title">Skills</div>
+            <div class="overview-card-value">${skillSummary.total} 个</div>
+            <div class="overview-card-meta">${skillSummary.eligible} 可用 · ${skillSummary.missing} 缺依赖</div>
           </div>
         </div>
 

--- a/src/pages/settings.js
+++ b/src/pages/settings.js
@@ -142,6 +142,12 @@ async function loadRegistry(page) {
 // ===== 事件绑定 =====
 
 function bindEvents(page) {
+  page.addEventListener('change', (e) => {
+    if (e.target?.matches?.('[data-name="cloudflared-mode"], [data-name="cloudflared-expose"], [data-name="cloudflared-port"]')) {
+      syncCloudflaredFormState(page)
+    }
+  })
+
   page.addEventListener('click', async (e) => {
     const btn = e.target.closest('[data-action]')
     if (!btn) return
@@ -244,3 +250,301 @@ async function handleSaveRegistry(page) {
   await api.setNpmRegistry(registry)
   toast('npm 源已保存', 'success')
 }
+
+// ===== Cloudflared 公网访问 =====
+
+function getCloudflaredForm(page) {
+  const mode = page.querySelector('[data-name="cloudflared-mode"]')?.value || 'quick'
+  const exposeTarget = page.querySelector('[data-name="cloudflared-expose"]')?.value || 'gateway'
+  const customPort = Number(page.querySelector('[data-name="cloudflared-port"]')?.value || 0)
+  const useHttp2 = !!page.querySelector('[data-name="cloudflared-http2"]')?.checked
+  const tunnelName = (page.querySelector('[data-name="cloudflared-tunnel"]')?.value || '').trim()
+  const hostname = (page.querySelector('[data-name="cloudflared-hostname"]')?.value || '').trim()
+  return { mode, exposeTarget, customPort, useHttp2, tunnelName, hostname }
+}
+
+function resolveExposePort(form) {
+  if (form.exposeTarget === 'webui') return 1420
+  if (form.exposeTarget === 'custom') return form.customPort || 18789
+  return 18789
+}
+
+function syncCloudflaredFormState(page) {
+  const form = getCloudflaredForm(page)
+  const modeBlocks = page.querySelectorAll('[data-cloudflared-mode-block]')
+  const exposeBlocks = page.querySelectorAll('[data-cloudflared-expose-block]')
+  modeBlocks.forEach(node => {
+    node.style.display = node.dataset.cloudflaredModeBlock === form.mode ? '' : 'none'
+  })
+  exposeBlocks.forEach(node => {
+    node.style.display = node.dataset.cloudflaredExposeBlock === form.exposeTarget ? '' : 'none'
+  })
+  const resolvedPortEl = page.querySelector('[data-cloudflared-resolved-port]')
+  if (resolvedPortEl) resolvedPortEl.textContent = String(resolveExposePort(form))
+}
+
+async function loadCloudflared(page) {
+  const el = page.querySelector('#cloudflared-bar')
+  if (!el) return
+
+  const cfg = await api.readPanelConfig()
+  if (!cfg.cloudflared || typeof cfg.cloudflared !== 'object') {
+    cfg.cloudflared = { mode: 'quick', exposeTarget: 'gateway', customPort: '', useHttp2: true, tunnelName: '', hostname: '' }
+    await api.writePanelConfig(cfg)
+  }
+  const saved = cfg.cloudflared || {}
+  const status = await api.cloudflaredGetStatus().catch(() => ({ installed: false, running: false }))
+
+  const mode = saved.mode || 'quick'
+  const exposeTarget = saved.exposeTarget || 'gateway'
+  const customPort = saved.customPort || ''
+  const useHttp2 = saved.useHttp2 !== false
+  const tunnelName = saved.tunnelName || ''
+  const hostname = saved.hostname || ''
+
+  el.innerHTML = `
+    <div class="stat-cards" style="grid-template-columns:repeat(auto-fit,minmax(180px,1fr));margin-bottom:var(--space-md)">
+      <div class="stat-card">
+        <div class="stat-card-header">
+          <span class="stat-card-label">运行状态</span>
+          <span class="status-dot ${status.running ? 'running' : 'stopped'}"></span>
+        </div>
+        <div class="stat-card-value">${status.running ? '运行中' : '未运行'}</div>
+        <div class="stat-card-meta">版本 ${escapeHtml(status.version || '未知')}</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-card-header"><span class="stat-card-label">当前模式</span></div>
+        <div class="stat-card-value">${mode === 'named' ? '命名隧道' : '快速隧道'}</div>
+        <div class="stat-card-meta">暴露 ${exposeTarget === 'gateway' ? 'Gateway' : exposeTarget === 'webui' ? 'Web UI' : '自定义端口'}</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-card-header"><span class="stat-card-label">实际端口</span></div>
+        <div class="stat-card-value" data-cloudflared-resolved-port>${resolveExposePort({ mode, exposeTarget, customPort, useHttp2, tunnelName, hostname })}</div>
+        <div class="stat-card-meta">启动时传给 cloudflared</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-card-header"><span class="stat-card-label">公网地址</span></div>
+        <div class="stat-card-value" style="font-size:var(--font-size-sm)">${status.url ? '已生成' : '未生成'}</div>
+        <div class="stat-card-meta">${status.url ? `<a href="${escapeHtml(status.url)}" target="_blank" rel="noopener">打开公网地址</a>` : '启动后自动生成'}</div>
+      </div>
+    </div>
+
+    <div style="display:flex;gap:8px;flex-wrap:wrap;margin-bottom:var(--space-md)">
+      <button class="btn btn-primary btn-sm" data-action="cloudflared-install">安装</button>
+      <button class="btn btn-secondary btn-sm" data-action="cloudflared-login">登录 Cloudflare</button>
+      ${status.running
+        ? '<button class="btn btn-danger btn-sm" data-action="cloudflared-stop">停止公网访问</button>'
+        : '<button class="btn btn-primary btn-sm" data-action="cloudflared-start">启动公网访问</button>'
+      }
+      <button class="btn btn-secondary btn-sm" data-action="cloudflared-refresh">刷新状态</button>
+      <button class="btn btn-secondary btn-sm" data-action="cloudflared-save">保存设置</button>
+    </div>
+
+    <div class="config-section" style="margin-bottom:var(--space-md)">
+      <div class="config-section-title">1. 选择暴露目标</div>
+      <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:10px;max-width:900px">
+        <label class="form-label">暴露目标
+          <select class="form-input" data-name="cloudflared-expose">
+            <option value="gateway" ${exposeTarget === 'gateway' ? 'selected' : ''}>Gateway 18789</option>
+            <option value="webui" ${exposeTarget === 'webui' ? 'selected' : ''}>Web UI 1420</option>
+            <option value="custom" ${exposeTarget === 'custom' ? 'selected' : ''}>自定义端口</option>
+          </select>
+        </label>
+        <div class="form-hint" style="align-self:end;padding-bottom:10px">推荐默认暴露 Gateway。选择 Gateway 时，会自动把 Cloudflare URL 写入 <code>gateway.controlUi.allowedOrigins</code>。</div>
+      </div>
+      <div class="config-section" data-cloudflared-expose-block="gateway" style="margin-top:var(--space-sm);padding:var(--space-sm);background:var(--bg-tertiary);border:1px solid var(--border-secondary)">
+        <div class="form-hint">固定暴露 OpenClaw Gateway，端口 18789，无需额外输入。</div>
+      </div>
+      <div class="config-section" data-cloudflared-expose-block="webui" style="margin-top:var(--space-sm);padding:var(--space-sm);background:var(--bg-tertiary);border:1px solid var(--border-secondary)">
+        <div class="form-hint">固定暴露 ClawPanel Web UI，端口 1420，适合只开放管理面板。</div>
+      </div>
+      <div class="config-section" data-cloudflared-expose-block="custom" style="margin-top:var(--space-sm);padding:var(--space-sm);background:var(--bg-tertiary);border:1px solid var(--border-secondary)">
+        <label class="form-label">自定义端口
+          <input class="form-input" data-name="cloudflared-port" placeholder="18789" value="${escapeHtml(String(customPort))}">
+        </label>
+        <div class="form-hint">只有在“自定义端口”模式下这里才生效。</div>
+      </div>
+    </div>
+
+    <div class="config-section" style="margin-bottom:var(--space-md)">
+      <div class="config-section-title">2. 选择隧道模式</div>
+      <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:10px;max-width:900px">
+        <label class="form-label">隧道类型
+          <select class="form-input" data-name="cloudflared-mode">
+            <option value="quick" ${mode === 'quick' ? 'selected' : ''}>快速隧道</option>
+            <option value="named" ${mode === 'named' ? 'selected' : ''}>命名隧道</option>
+          </select>
+        </label>
+        <label class="form-label">启用 HTTP/2
+          <input type="checkbox" data-name="cloudflared-http2" ${useHttp2 ? 'checked' : ''}>
+        </label>
+      </div>
+      <div class="config-section" data-cloudflared-mode-block="quick" style="margin-top:var(--space-sm);padding:var(--space-sm);background:var(--bg-tertiary);border:1px solid var(--border-secondary)">
+        <div class="form-hint">快速隧道无需隧道名和域名，适合临时开放，启动后自动生成公网地址。</div>
+      </div>
+      <div class="config-section" data-cloudflared-mode-block="named" style="margin-top:var(--space-sm);padding:var(--space-sm);background:var(--bg-tertiary);border:1px solid var(--border-secondary)">
+        <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:10px;max-width:900px">
+          <label class="form-label">隧道名称
+            <input class="form-input" data-name="cloudflared-tunnel" value="${escapeHtml(tunnelName)}" placeholder="my-openclaw-tunnel">
+          </label>
+          <label class="form-label">绑定域名
+            <input class="form-input" data-name="cloudflared-hostname" value="${escapeHtml(hostname)}" placeholder="openclaw.example.com">
+          </label>
+        </div>
+        <div class="form-hint">命名隧道适合长期使用。通常先登录，再填写隧道名称和域名。</div>
+      </div>
+    </div>
+
+    <div class="form-hint">
+      推荐顺序：安装 → 登录 Cloudflare → 选择暴露目标 → 选择隧道模式 → 保存设置 → 启动公网访问。
+    </div>
+  `
+  syncCloudflaredFormState(page)
+}
+
+async function handleCloudflaredSave(page) {
+  const cfg = await api.readPanelConfig()
+  const form = getCloudflaredForm(page)
+  cfg.cloudflared = {
+    mode: form.mode,
+    exposeTarget: form.exposeTarget,
+    customPort: form.customPort,
+    useHttp2: form.useHttp2,
+    tunnelName: form.tunnelName,
+    hostname: form.hostname,
+  }
+  await api.writePanelConfig(cfg)
+  toast('Cloudflared 设置已保存', 'success')
+}
+
+async function handleCloudflaredInstall(page) {
+  await api.cloudflaredInstall()
+  await loadCloudflared(page)
+  toast('Cloudflared 已安装', 'success')
+}
+
+async function handleCloudflaredLogin(page) {
+  await api.cloudflaredLogin()
+  await loadCloudflared(page)
+  toast('Cloudflared 登录完成', 'success')
+}
+
+async function handleCloudflaredStart(page) {
+  const form = getCloudflaredForm(page)
+  const port = resolveExposePort(form)
+  await handleCloudflaredSave(page)
+  await api.cloudflaredStart({
+    mode: form.mode,
+    port,
+    use_http2: form.useHttp2,
+    tunnel_name: form.tunnelName || null,
+    hostname: form.hostname || null,
+    add_allowed_origins: true,
+    expose_target: form.exposeTarget,
+  })
+  await loadCloudflared(page)
+  toast('Cloudflared 已启动', 'success')
+}
+
+async function handleCloudflaredStop(page) {
+  await api.cloudflaredStop()
+  await loadCloudflared(page)
+  toast('Cloudflared 已停止', 'success')
+}
+
+// ===== OpenClaw CLI =====
+
+async function loadOpenclawCli(page) {
+  const bar = page.querySelector('#openclaw-bar')
+  if (!bar) return
+  try {
+    const [cfg, services] = await Promise.all([
+      api.readPanelConfig(),
+      api.getServicesStatus(),
+    ])
+    const svc = Array.isArray(services)
+      ? services.find(s => s.label === 'ai.openclaw.gateway' || s.id === 'ai.openclaw.gateway' || s.name === 'ai.openclaw.gateway' || s.label === 'openclaw' || s.id === 'openclaw')
+      : null
+    const overridePath = cfg?.openclawPath || ''
+    const cliMeta = buildOpenclawCliMeta(svc, { overridePath })
+    const detectedPath = cliMeta.path || ''
+    const detectedVersion = cliMeta.version || ''
+    const candidates = Array.isArray(svc?.cli_candidates) ? svc.cli_candidates : []
+    const selectedValue = overridePath || detectedPath || ''
+
+    bar.innerHTML = `
+      <div style="display:flex;flex-direction:column;gap:6px">
+        <div style="display:flex;flex-wrap:wrap;gap:8px;align-items:center">
+          <span class="status-dot ${cliMeta.installed ? 'running' : 'stopped'}"></span>
+          <span>${escapeHtml(cliMeta.statusLabel)}</span>
+          ${detectedVersion ? `<span style="color:var(--text-tertiary)">CLI 版本: ${escapeHtml(detectedVersion)}</span>` : ''}
+          <span style="color:var(--text-tertiary)">路径来源: ${escapeHtml(cliMeta.pathSourceLabel)}</span>
+          <span style="color:var(--text-tertiary)">路径策略: ${escapeHtml(cliMeta.strategyLabel)}</span>
+        </div>
+        ${detectedPath ? `<div style="font-size:var(--font-size-xs);color:var(--text-tertiary)">CLI 路径: <span style="font-family:monospace;word-break:break-all">${escapeHtml(detectedPath)}</span></div>` : ''}
+        ${detectedVersion ? `<div style="font-size:var(--font-size-xs);color:var(--text-tertiary)">版本来源: ${escapeHtml(cliMeta.versionSourceLabel)}</div>` : ''}
+        <div style="display:flex;gap:8px;flex-wrap:wrap;margin-top:4px">
+          <select class="form-input" data-name="openclaw-candidate" style="max-width:520px">
+            <option value="">自动检测当前 PATH</option>
+            ${candidates.map(p => `<option value="${escapeHtml(p)}" ${p === selectedValue ? 'selected' : ''}>${escapeHtml(p)}</option>`).join('')}
+          </select>
+          <input class="form-input" data-name="openclaw-path" placeholder="C:\\Program Files\\OpenClaw\\openclaw.cmd" value="${escapeHtml(String(overridePath || detectedPath))}" style="max-width:520px">
+          <button class="btn btn-primary btn-sm" data-action="openclaw-save">保存路径</button>
+          <button class="btn btn-secondary btn-sm" data-action="openclaw-clear">清除覆盖</button>
+          <button class="btn btn-secondary btn-sm" data-action="openclaw-refresh">刷新检测</button>
+          <button class="btn btn-secondary btn-sm" data-action="openclaw-setup">进入初始化设置</button>
+        </div>
+        <div class="form-hint" style="margin-top:4px">
+          保存路径后将优先使用该路径检测与启动 Gateway。若检测到多条 CLI 路径，可先在下拉框中选中再保存。清除覆盖会回退到自动检测。
+        </div>
+      </div>
+    `
+
+    const candidateSelect = bar.querySelector('[data-name="openclaw-candidate"]')
+    const pathInput = bar.querySelector('[data-name="openclaw-path"]')
+    candidateSelect?.addEventListener('change', () => {
+      if (candidateSelect.value) pathInput.value = candidateSelect.value
+    })
+  } catch (e) {
+    bar.innerHTML = `<div style="color:var(--error)">加载失败: ${escapeHtml(String(e))}</div>`
+  }
+}
+
+async function handleOpenclawSave(page) {
+  const candidate = page.querySelector('[data-name="openclaw-candidate"]')
+  const input = page.querySelector('[data-name="openclaw-path"]')
+  const inputValue = String(input?.value || '').trim()
+  const candidateValue = String(candidate?.value || '').trim()
+  const value = inputValue || candidateValue
+  const cfg = await api.readPanelConfig()
+  if (!value) {
+    delete cfg.openclawPath
+    await api.writePanelConfig(cfg)
+    toast('路径为空，已清除覆盖', 'info')
+    await loadOpenclawCli(page)
+    return
+  }
+  cfg.openclawPath = value
+  await api.writePanelConfig(cfg)
+  toast('OpenClaw 路径已保存', 'success')
+  await loadOpenclawCli(page)
+}
+
+async function handleOpenclawClear(page) {
+  const cfg = await api.readPanelConfig()
+  delete cfg.openclawPath
+  await api.writePanelConfig(cfg)
+  toast('OpenClaw 路径覆盖已清除', 'success')
+  await loadOpenclawCli(page)
+}
+
+async function handleOpenclawSetup() {
+  try {
+    const cfg = await api.readPanelConfig().catch(() => ({}))
+    await api.writePanelConfig({ ...cfg, forceSetup: true, skipSetup: false })
+    window.location.hash = '#/setup'
+  } catch (e) {
+    toast('进入初始化设置失败: ' + (e?.message || e), 'error')
+  }
+}
+>>>>>>> efc1531 (refactor: layer cloudflared access form)

--- a/src/pages/settings.js
+++ b/src/pages/settings.js
@@ -321,6 +321,7 @@ async function loadCloudflared(page) {
   }
   const saved = cfg.cloudflared || {}
   const status = await api.cloudflaredGetStatus().catch(() => ({ installed: false, running: false }))
+  page.__cloudflaredInstalled = !!status.installed
 
   const mode = saved.mode || 'quick'
   const exposeTarget = saved.exposeTarget || 'gateway'
@@ -463,6 +464,11 @@ async function handleCloudflaredLogin(page) {
 
 async function handleCloudflaredStart(page) {
   const form = getCloudflaredForm(page)
+  if (page.__cloudflaredInstalled === false) {
+    syncCloudflaredFormState(page)
+    toast('请先安装 Cloudflared', 'warning')
+    return
+  }
   const validationError = validateCloudflaredForm(form)
   if (validationError) {
     syncCloudflaredFormState(page)

--- a/src/pages/settings.js
+++ b/src/pages/settings.js
@@ -451,6 +451,11 @@ async function handleCloudflaredInstall(page) {
 }
 
 async function handleCloudflaredLogin(page) {
+  if (page.__cloudflaredInstalled === false) {
+    toast('请先安装 Cloudflared', 'warning')
+    syncCloudflaredFormState(page)
+    return
+  }
   await api.cloudflaredLogin()
   await loadCloudflared(page)
   toast('Cloudflared 登录完成', 'success')

--- a/src/pages/settings.js
+++ b/src/pages/settings.js
@@ -269,6 +269,19 @@ function resolveExposePort(form) {
   return 18789
 }
 
+function validateCloudflaredForm(form) {
+  if (form.exposeTarget === 'custom' && !(Number(form.customPort) > 0)) {
+    return '自定义端口模式下必须填写有效端口'
+  }
+  if (form.mode === 'named' && !form.tunnelName) {
+    return '命名隧道模式下必须填写隧道名称'
+  }
+  if (form.mode === 'named' && !form.hostname) {
+    return '命名隧道模式下必须填写绑定域名'
+  }
+  return ''
+}
+
 function syncCloudflaredFormState(page) {
   const form = getCloudflaredForm(page)
   const modeBlocks = page.querySelectorAll('[data-cloudflared-mode-block]')
@@ -281,6 +294,20 @@ function syncCloudflaredFormState(page) {
   })
   const resolvedPortEl = page.querySelector('[data-cloudflared-resolved-port]')
   if (resolvedPortEl) resolvedPortEl.textContent = String(resolveExposePort(form))
+  const customPortInput = page.querySelector('[data-name="cloudflared-port"]')
+  if (customPortInput) customPortInput.disabled = form.exposeTarget !== 'custom'
+  const tunnelNameInput = page.querySelector('[data-name="cloudflared-tunnel"]')
+  const hostnameInput = page.querySelector('[data-name="cloudflared-hostname"]')
+  if (tunnelNameInput) tunnelNameInput.disabled = form.mode !== 'named'
+  if (hostnameInput) hostnameInput.disabled = form.mode !== 'named'
+  const validationEl = page.querySelector('[data-cloudflared-validation]')
+  const errorText = validateCloudflaredForm(form)
+  if (validationEl) {
+    validationEl.textContent = errorText || '当前配置可直接保存；启动前会按你的选择自动计算实际端口。'
+    validationEl.style.color = errorText ? 'var(--warning)' : 'var(--text-tertiary)'
+  }
+  const startBtn = page.querySelector('[data-action="cloudflared-start"]')
+  if (startBtn) startBtn.disabled = !!errorText
 }
 
 async function loadCloudflared(page) {
@@ -431,6 +458,12 @@ async function handleCloudflaredLogin(page) {
 
 async function handleCloudflaredStart(page) {
   const form = getCloudflaredForm(page)
+  const validationError = validateCloudflaredForm(form)
+  if (validationError) {
+    syncCloudflaredFormState(page)
+    toast(validationError, 'warning')
+    return
+  }
   const port = resolveExposePort(form)
   await handleCloudflaredSave(page)
   await api.cloudflaredStart({
@@ -547,4 +580,3 @@ async function handleOpenclawSetup() {
     toast('进入初始化设置失败: ' + (e?.message || e), 'error')
   }
 }
->>>>>>> efc1531 (refactor: layer cloudflared access form)

--- a/src/pages/skills.js
+++ b/src/pages/skills.js
@@ -101,8 +101,35 @@ function renderSkills(el, data) {
       ${!cliAvailable ? '<span class="form-hint" style="margin-left:auto;color:var(--warning)">CLI 不可用，仅显示本地扫描结果</span>' : ''}
     </div>
 
+    <div class="stat-cards" style="margin-bottom:var(--space-md)">
+      <div class="stat-card">
+        <div class="stat-card-header"><span class="stat-card-label">Skills 总数</span></div>
+        <div class="stat-card-value">${skills.length}</div>
+        <div class="stat-card-meta">已扫描本地可见技能</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-card-header"><span class="stat-card-label">可直接使用</span></div>
+        <div class="stat-card-value">${eligible.length}</div>
+        <div class="stat-card-meta">环境与依赖已满足</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-card-header"><span class="stat-card-label">待处理</span></div>
+        <div class="stat-card-value">${missing.length + blocked.length}</div>
+        <div class="stat-card-meta">${missing.length} 缺依赖 · ${blocked.length} 已阻止</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-card-header"><span class="stat-card-label">不可用</span></div>
+        <div class="stat-card-value">${disabled.length}</div>
+        <div class="stat-card-meta">当前已禁用</div>
+      </div>
+    </div>
+
     <div class="skills-summary" style="margin-bottom:var(--space-lg);color:var(--text-secondary);font-size:var(--font-size-sm)">
       共 ${skills.length} 个 Skills: ${summary}
+    </div>
+
+    <div class="clawhub-empty" id="skill-filter-empty" style="display:none;margin-bottom:var(--space-lg);text-align:center;padding:var(--space-lg)">
+      当前过滤条件下没有匹配的 Skills
     </div>
 
     ${eligible.length ? `
@@ -153,14 +180,19 @@ function renderSkills(el, data) {
 
   // 实时过滤
   const input = el.querySelector('#skill-filter-input')
+  const emptyEl = el.querySelector('#skill-filter-empty')
   if (input) {
     input.addEventListener('input', () => {
       const q = input.value.trim().toLowerCase()
+      let visibleCount = 0
       el.querySelectorAll('.skill-card-item').forEach(card => {
         const name = (card.dataset.name || '').toLowerCase()
         const desc = (card.dataset.desc || '').toLowerCase()
-        card.style.display = (!q || name.includes(q) || desc.includes(q)) ? '' : 'none'
+        const visible = !q || name.includes(q) || desc.includes(q)
+        card.style.display = visible ? '' : 'none'
+        if (visible) visibleCount += 1
       })
+      if (emptyEl) emptyEl.style.display = q && visibleCount === 0 ? '' : 'none'
     })
   }
 }

--- a/src/pages/skills.js
+++ b/src/pages/skills.js
@@ -4,6 +4,7 @@
  */
 import { api } from '../lib/tauri-api.js'
 import { toast } from '../components/toast.js'
+import { invalidateSkillsCatalog, getCachedSkillsCatalog, loadSkillsCatalog } from '../lib/skills-catalog.js'
 
 let _loadSeq = 0
 
@@ -51,22 +52,29 @@ export async function render() {
   return page
 }
 
-async function loadSkills(page) {
+async function loadSkills(page, options = {}) {
   const el = page.querySelector('#skills-tab-installed')
   if (!el) return
   const seq = ++_loadSeq
+  const force = !!options.force
+  const cached = !force ? getCachedSkillsCatalog() : null
 
-  el.innerHTML = `<div class="skills-loading-panel">
-    <div class="stat-card loading-placeholder" style="height:96px"></div>
-    <div class="form-hint" style="margin-top:8px">正在加载 Skills...</div>
-  </div>`
+  if (cached) {
+    renderSkills(el, cached)
+  } else {
+    el.innerHTML = `<div class="skills-loading-panel">
+      <div class="stat-card loading-placeholder" style="height:96px"></div>
+      <div class="form-hint" style="margin-top:8px">正在加载 Skills...</div>
+    </div>`
+  }
 
   try {
-    const data = await api.skillsList()
+    const data = await loadSkillsCatalog({ force })
     if (seq !== _loadSeq) return
     renderSkills(el, data)
   } catch (e) {
     if (seq !== _loadSeq) return
+    if (cached) return
     el.innerHTML = `<div class="skills-load-error">
       <div style="color:var(--error);margin-bottom:8px">加载失败: ${esc(e?.message || e)}</div>
       <div class="form-hint" style="margin-bottom:10px">请确认 OpenClaw 已安装并可用</div>
@@ -83,7 +91,7 @@ function renderSkills(el, data) {
   const disabled = skills.filter(s => s.disabled)
   const blocked = skills.filter(s => s.blockedByAllowlist && !s.disabled)
 
-  const summary = `${eligible.length} 可用 / ${missing.length} 缺依赖 / ${disabled.length} 已禁用`
+  const summary = `${eligible.length} 可用 / ${missing.length} 缺依赖 / ${disabled.length} 已禁用 / ${blocked.length} 已阻止`
 
   el.innerHTML = `
     <div class="clawhub-toolbar">
@@ -431,7 +439,8 @@ function bindEvents(page) {
     if (!btn) return
     switch (btn.dataset.action) {
       case 'skill-retry':
-        await loadSkills(page)
+        invalidateSkillsCatalog()
+        await loadSkills(page, { force: true })
         break
       case 'skill-info':
         await handleInfo(page, btn.dataset.name)

--- a/src/style/layout.css
+++ b/src/style/layout.css
@@ -19,7 +19,8 @@
 #sidebar.sidebar-collapsed .nav-section-title,
 #sidebar.sidebar-collapsed .nav-item span,
 #sidebar.sidebar-collapsed .sidebar-meta,
-#sidebar.sidebar-collapsed .instance-switcher {
+#sidebar.sidebar-collapsed .instance-switcher,
+#sidebar.sidebar-collapsed .nav-section-toggle {
   display: none;
 }
 #sidebar.sidebar-collapsed .sidebar-header {
@@ -247,13 +248,44 @@
   margin-bottom: var(--space-md);
 }
 
+.nav-section-toggle {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-sm);
+  padding: 6px var(--space-sm);
+  margin-bottom: var(--space-xs);
+  border: 0;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--text-tertiary);
+  cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease;
+}
+
+.nav-section-toggle:hover {
+  background: var(--bg-glass-hover);
+  color: var(--text-secondary);
+}
+
 .nav-section-title {
   font-size: var(--font-size-xs);
-  color: var(--text-tertiary);
+  color: inherit;
   text-transform: uppercase;
   letter-spacing: 0.5px;
-  padding: var(--space-sm) var(--space-sm);
-  margin-bottom: var(--space-xs);
+  text-align: left;
+}
+
+.nav-section-chevron {
+  min-width: 16px;
+  text-align: center;
+  font-size: 14px;
+  line-height: 1;
+}
+
+.nav-section-items {
+  display: block;
 }
 
 .nav-item {


### PR DESCRIPTION
## Summary
- optimize dashboard skills overview and align summary wording with the Skills page
- add collapsible sidebar groups for clearer navigation
- layer the Cloudflared settings flow into status, actions, expose target, and tunnel mode
- harden Cloudflared validation, action states, and install-state visibility
- polish Skills overview states and filter empty-state handling

## Validation
- npm run build
- npx vitest run

## Validation Notes
- 
pm run build passes on this split branch
- 
px vitest run fails on upstream main baseline because the current upstream test set references modules/scripts that only exist in the downstream fork history (for example src/lib/docker-tasking.js and newer Vitest wiring), so the failure is pre-existing relative to this branch scope