### PR TITLE
fix(models): stop auto-populating fallbacks on every save

### DIFF
--- a/src/pages/models.js
+++ b/src/pages/models.js
@@ -729,17 +729,36 @@ function ensureValidPrimary(state) {
 function applyDefaultModel(state) {
   ensureValidPrimary(state)
   const primary = getCurrentPrimary(state.config)
-  const allModels = collectAllModels(state.config)
-  const fallbacks = allModels.filter(m => m.full !== primary).map(m => m.full)
 
+  // 确保 defaults.model 存在
   const defaults = state.config.agents.defaults
-  defaults.model.primary = primary
-  defaults.model.fallbacks = fallbacks
+  if (!defaults.model) defaults.model = {}
 
-  const modelsMap = {}
-  modelsMap[primary] = {}
-  for (const fb of fallbacks) modelsMap[fb] = {}
-  defaults.models = modelsMap
+  // 只同步 primary，不自动重写 fallbacks / models
+  // ———————————————————————————————————————————
+  // 原逻辑会把所有非主模型强制塞进 fallbacks 并重建 defaults.models，
+  // 导致用户精心维护的精简 fallback 链被覆盖，且随模型增多而不断膨胀，
+  // 可能引起频繁 failover 卡顿（参考 https://github.com/qingchencloud/clawpanel/issues/190）
+  //
+  // 保留 primary 同步（确保主模型始终有效）；
+  // fallback 由用户自行在 openclaw.json 中维护，ClawPanel 不再主动干预。
+  // ———————————————————————————————————————————
+  defaults.model.primary = primary
+
+  // 如 model 对象尚未初始化 fallbacks / models，再初始化一次（首次安装时友好）
+  if (!defaults.model.fallbacks) {
+    const allModels = collectAllModels(state.config)
+    const fallbacks = allModels.filter(m => m.full !== primary).map(m => m.full)
+    defaults.model.fallbacks = fallbacks
+  }
+  if (!defaults.model.models) {
+    const allModels = collectAllModels(state.config)
+    const fallbacks = allModels.filter(m => m.full !== primary).map(m => m.full)
+    const modelsMap = {}
+    modelsMap[primary] = {}
+    for (const fb of fallbacks) modelsMap[fb] = {}
+    defaults.model.models = modelsMap
+  }
 
   // 注意：不再强制同步到各 agent 的 model.primary
   // 子 Agent 的模型覆盖是 OpenClaw 正常功能（用户可通过对话为不同 Agent 设置不同模型）


### PR DESCRIPTION
## Summary applyDefaultModel() currently overwrites agents.defaults.model.fallbacks with ALL non-primary models on every save (add/edit/delete/sort/set-primary on the models page). As the model list grows, this creates an ever-expanding fallback chain that causes frequent failover stalls. ## What changed applyDefaultModel(state) now only syncs defaults.model.primary on every save. The fallbacks and defaults.models fields are only initialized when they are empty (first install scenario), not blindly overwritten. This preserves user-curated fallback chains while keeping the primary-model validation logic intact. ## Behavior | Scenario | Before | After | |----------|--------|-------| | Every save on models page | Fallback = ALL non-primary models | Fallback unchanged | | First install (empty fallback) | Initializes with all models | Initializes with all models | | Primary model deleted | Auto-switches to first model | Auto-switches | ## Cross-platform note This fix touches only src/pages/models.js, the React web frontend. It applies equally to Windows, macOS, and Linux deployments. Fixes #190