### PR TITLE
fix: 修复多实例共存时无法获取实际运行实例版本号的问题

### DIFF
--- a/src-tauri/src/commands/config.rs
+++ b/src-tauri/src/commands/config.rs
@@ -2638,6 +2638,17 @@ fn read_version_from_installation(cli_path: &std::path::Path) -> Option<String> 
                 }
             }
         }
+        // CLI 本体位于包目录中时（如 npm 全局安装：nvm、Homebrew 等），
+        // 直接读取同目录的 package.json（即该包自身的版本文件）
+        let own_pkg = dir.join("package.json");
+        if let Ok(content) = std::fs::read_to_string(&own_pkg) {
+            if let Some(ver) = serde_json::from_str::<serde_json::Value>(&content)
+                .ok()
+                .and_then(|v| v.get("version")?.as_str().map(String::from))
+            {
+                return Some(ver);
+            }
+        }
         // 根据 CLI 路径判断来源，决定 package.json 检查顺序
         // 避免残留的另一来源包被优先读取
         let cli_source = crate::utils::classify_cli_source(&cli_path.to_string_lossy());

--- a/src-tauri/src/commands/config.rs
+++ b/src-tauri/src/commands/config.rs
@@ -1891,6 +1891,23 @@ pub fn write_mcp_config(config: Value) -> Result<(), String> {
 /// macOS: 优先从 npm 包的 package.json 读取（含完整后缀），fallback 到 CLI
 /// Windows/Linux: 优先读文件系统，fallback 到 CLI
 async fn get_local_version() -> Option<String> {
+    // 优先从运行中的 openclaw 实例获取版本（openclaw status --json → runtimeVersion）
+    // 避免多实例共存时读取到非活跃安装的版本
+    if let Ok(output) = crate::utils::openclaw_command_async()
+        .args(["status", "--json"])
+        .output()
+        .await
+    {
+        if output.status.success() {
+            let stdout = String::from_utf8_lossy(&output.stdout);
+            if let Some(ver) = crate::commands::skills::extract_json_pub(&stdout)
+                .and_then(|v| v.get("runtimeVersion")?.as_str().map(String::from))
+            {
+                return Some(ver);
+            }
+        }
+    }
+
     #[cfg(target_os = "macos")]
     {
         if let Some(cli_path) = crate::utils::resolve_openclaw_cli_path() {

--- a/src-tauri/src/utils.rs
+++ b/src-tauri/src/utils.rs
@@ -110,15 +110,18 @@ pub fn resolve_openclaw_cli_path() -> Option<String> {
     }
     #[cfg(not(target_os = "windows"))]
     {
-        for candidate in common_non_windows_cli_candidates() {
-            if candidate.exists() {
-                return Some(candidate.to_string_lossy().to_string());
-            }
-        }
+        // 优先通过 enhanced_path 搜索：其中 nvm/volta 等版本管理器路径排在 Homebrew 前面，
+        // 与 `which openclaw` 的优先级一致，避免残留的 Homebrew 旧版本被优先检测到
         let path = crate::commands::enhanced_path();
         let sep = ':';
         for dir in path.split(sep) {
             let candidate = std::path::Path::new(dir).join("openclaw");
+            if candidate.exists() {
+                return Some(candidate.to_string_lossy().to_string());
+            }
+        }
+        // 兜底：检查 enhanced_path 可能未覆盖到的固定路径（如 GUI 环境 PATH 受限时）
+        for candidate in common_non_windows_cli_candidates() {
             if candidate.exists() {
                 return Some(candidate.to_string_lossy().to_string());
             }


### PR DESCRIPTION
## 问题描述

当系统存在两个 openclaw 实例时（如 nvm 管理的新版本与 Homebrew 遗留的旧版本共存），面板无法获取实际运行实例的版本号，显示的是非活跃的旧版本。

## 根因分析

**1. `get_local_version` 通过文件路径推断版本，无法反映正在运行的实例（`config.rs`）**

函数通过读取磁盘上的 `VERSION` 文件或 `package.json` 来获取版本号，本质上是"猜测"当前安装的版本，与正在运行的进程无关。当多个实例共存时，读到哪个文件取决于路径查找的优先级，而非实际运行的是哪个实例。

**2. `resolve_openclaw_cli_path` 路径优先级错误，硬编码 Homebrew 路径排在 PATH 之前（`utils.rs`）**

非 Windows 平台的查找顺序为：硬编码路径（含 `/opt/homebrew/bin/openclaw`）→ `enhanced_path()` PATH 搜索。而 `enhanced_path()` 内部已将 nvm/volta 等版本管理器路径排在 Homebrew 之前。由于硬编码路径先执行，只要 `/opt/homebrew/bin/openclaw` 存在，就会被优先返回，完全绕过 nvm 激活的实例。

**3. `read_version_from_installation` 无法从 npm 全局安装结构中读取版本（`config.rs`）**

函数只查找 `dir/node_modules/<pkg>/package.json`，但 npm 全局安装（nvm/Homebrew 均为此结构）的 CLI 文件本身就位于包目录内，版本文件直接是 `dir/package.json`，导致函数始终返回 `None`，代码继续向下触发 Homebrew 兜底逻辑，读到旧版本号。

## 修改方案

**Fix 1：`get_local_version` 优先查询运行实例（`config.rs`）**

在函数最开头执行 `openclaw status --json`，从返回值的 `runtimeVersion` 字段直接取版本号。这是运行中的 openclaw 实例自身汇报的版本，与磁盘上有多少个安装无关。仅当 openclaw 未运行（命令失败或无该字段）时，才降级到原有的文件读取逻辑。

**Fix 2：`resolve_openclaw_cli_path` 调整路径查找优先级（`utils.rs`）**

将 `enhanced_path()` 搜索提前，`common_non_windows_cli_candidates()` 硬编码路径降为兜底。`enhanced_path()` 已将 nvm 版本目录按版本号倒序排在 Homebrew 之前，调整后与 `which openclaw` 优先级一致。硬编码路径仅保留作为 GUI 环境 PATH 受限时的兜底。

**Fix 3：`read_version_from_installation` 增加读取 `dir/package.json`（`config.rs`）**

在 `VERSION` 文件检查之后、`node_modules` 搜索之前，新增直接读取 `dir/package.json` 的逻辑，正确处理 CLI 本体位于包目录中的 npm 全局安装场景（nvm/Homebrew 均为此结构）。

修复后完整降级链路：

```
openclaw status --json → runtimeVersion   ← 运行实例（主路径）
  ↓ 失败（服务未运行）
resolve_openclaw_cli_path（enhanced_path 优先）
  → read_version_from_installation
      → VERSION 文件
      → dir/package.json                  ← Fix 3 新增
      → dir/node_modules/<pkg>/package.json
  ↓ 全部失败
openclaw --version                        ← 最终兜底
```

## 验证结果

复现环境：macOS，nvm 管理 openclaw `2026.4.11`（活跃），Homebrew 遗留 openclaw `2026.3.23-2`（非活跃，Node.js 已卸载）。

| | 修复前 | 修复后 |
|---|---|---|
| 版本来源 | Homebrew 兜底 `package.json` | `openclaw status --json` → `runtimeVersion` |
| 面板显示版本 | `2026.3.23-2` ❌ | `2026.4.11` ✅ |
| 与 `openclaw --version` 一致 | 否 | 是 |