### PR TITLE
fix(models): recognize google-generative-ai as google-gemini api type

### DIFF
--- a/src-tauri/src/commands/config.rs
+++ b/src-tauri/src/commands/config.rs
@@ -5063,7 +5063,7 @@ fn normalize_base_url(raw: &str) -> String {
 fn normalize_model_api_type(raw: &str) -> &'static str {
     match raw.trim() {
         "anthropic" | "anthropic-messages" => "anthropic-messages",
-        "google-gemini" => "google-gemini",
+        "google-gemini" | "google-generative-ai" => "google-gemini",
         "openai" | "openai-completions" | "openai-responses" | "" => "openai-completions",
         _ => "openai-completions",
     }


### PR DESCRIPTION
## 问题

关联 Issue：#239

前端 `PROVIDER_PRESETS` 中，Google 供应商的 `api` 字段被定义为 `"google-generative-ai"`，而后端 `normalize_model_api_type()` 函数只识别 `"google-gemini"`。

这导致 `google-generative-ai` 类型被 fallthrough 到默认的 `"openai-completions"`，进而使 `list_remote_models()`、`test_model()`、`probe_model()` 等函数都错误地发送 `Authorization: Bearer` 请求头，而非 Google Generative Language API 要求的 `?key=` 查询参数，最终返回 **401 Unauthorized**。

## 修复

在 `normalize_model_api_type()` 的 match arm 中，将 `"google-generative-ai"` 作为 `"google-gemini"` 的别名加入：

```rust
// Before
"google-gemini" => "google-gemini",

// After
"google-gemini" | "google-generative-ai" => "google-gemini",
```

## 影响范围

- 影响文件：`src-tauri/src/commands/config.rs`，仅修改 1 行
- 不影响任何现有逻辑；已使用 `"google-gemini"` 的配置行为不变
- 修复后，前端以 `api: "google-generative-ai"` 配置 Google 供应商时，获取模型列表、测试连接均可正常工作