### PR TITLE
refactor(models): 重构主模型设置流程与持久化生命周期

### DIFF
--- a/src/pages/models.js
+++ b/src/pages/models.js
@@ -116,7 +116,7 @@ function collectAllModels(config) {
       if (id) result.push({ provider: pk, modelId: id, full: `${pk}/${id}` })
     }
   }
-  return resul
+  return result
 }
 
 function getApiTypeLabel(apiType) {
@@ -263,6 +263,7 @@ function bindWaterfallActions(page, state) {
       pushUndo(state)
       modelConfig.fallbacks = modelConfig.fallbacks.filter(f => f !== id)
       renderDefaultBar(page, state)
+      renderProviders(page, state)
       updateUndoBtn(page, state)
       autoSave(state)
     }
@@ -272,18 +273,10 @@ function bindWaterfallActions(page, state) {
   container.querySelectorAll('.btn-set-primary-from-fb').forEach(btn => {
     btn.onclick = () => {
       const full = btn.dataset.id
-      const oldPrimary = getCurrentPrimary(state.config)
-      const fallbacks = state.config.agents.defaults.model.fallbacks || []
-
       pushUndo(state)
-      // 1. 设置新主模型
       setPrimary(state, full)
-      // 2. 将旧主模型放入备选链（原位置或末尾）
-      const newFallbacks = fallbacks.filter(f => f !== full)
-      if (oldPrimary) newFallbacks.push(oldPrimary)
-      state.config.agents.defaults.model.fallbacks = newFallbacks
-
       renderDefaultBar(page, state)
+      renderProviders(page, state)
       updateUndoBtn(page, state)
       autoSave(state)
       toast(t('models.setAsPrimarySuccess', { model: full }), 'success')
@@ -299,6 +292,7 @@ function bindWaterfallActions(page, state) {
       pushUndo(state)
       modelConfig.fallbacks.push(full)
       renderDefaultBar(page, state)
+      renderProviders(page, state)
       updateUndoBtn(page, state)
       autoSave(state)
     }
@@ -618,17 +612,24 @@ async function undo(page, state) {
 // 自动保存（防抖 300ms）+ Gateway 重启队列（3s 防抖 + 单飞行锁）
 // 解决 issue #243 / #244 / #240：快速连续编辑不再触发多次重启
 let _saveTimer = null
+let _pendingSaveState = null // cleanup 时用于执行 pending 的保存
 let _batchTestAbort = null // 批量测试终止控制器
 
 export function cleanup() {
-  clearTimeout(_saveTimer)
-  _saveTimer = null
+  // 有 pending 的自动保存时，立即执行，防止页面切换时丢失变更
+  if (_saveTimer !== null) {
+    clearTimeout(_saveTimer)
+    _saveTimer = null
+    if (_pendingSaveState) doAutoSave(_pendingSaveState)
+  }
+  _pendingSaveState = null
   if (_batchTestAbort) { _batchTestAbort.abort = true; _batchTestAbort = null }
   cancelPendingRestart()
 }
 function autoSave(state) {
   clearTimeout(_saveTimer)
-  _saveTimer = setTimeout(() => doAutoSave(state), 300)
+  _pendingSaveState = state
+  _saveTimer = setTimeout(() => { _saveTimer = null; _pendingSaveState = null; doAutoSave(state) }, 300)
 }
 
 /** 已知的 API 类型错误→正确映射,自动修复用户手动编辑或旧版本配置 */
@@ -976,9 +977,32 @@ async function handleAction(action, btn, card, section, providerKey, provider, p
   }
 }
 
-// 设置主模型(仅修改 state,不写入文件)
+// 设置主模型入口
 function setPrimary(state, full) {
+  const oldPrimary = getCurrentPrimary(state.config)
+  if (oldPrimary === full) return
+
+  // 1. 设置新主模型状态
   ensureDefaultModelConfig(state).primary = full
+
+  // 2. 轮转备选链状态
+  rotateFallbackChain(state, oldPrimary, full)
+}
+
+// 处理主模型变更后，备选链的数据流转
+function rotateFallbackChain(state, oldPrimary, newPrimary) {
+  const modelConfig = ensureDefaultModelConfig(state)
+  const fallbacks = modelConfig.fallbacks || []
+  
+  // 从备选链中移除新上位的主模型
+  const newFallbacks = fallbacks.filter(f => f !== newPrimary)
+  
+  // 将原主模型降级放入备选链
+  if (oldPrimary) {
+    newFallbacks.push(oldPrimary)
+  }
+  
+  modelConfig.fallbacks = newFallbacks
 }
 
 // 应用默认模型:primary + 其余自动成为备选


### PR DESCRIPTION
本次提交重构了模型管理页面的状态流转逻辑，以降低业务侵入性并解决由于代码分散导致的状态不同步问题。

**1. 主/备模型轮转逻辑解耦：**
- **重构 `setPrimary` 函数**：将原来散落在 UI 按钮点击事件中的 fallback 链处理逻辑抽离，封装出独立的 `rotateFallbackChain` 流程。
- **入口归一化**：现在无论是从“系统主/备模型”模块还是“模型供应商”模块设置主模型，底层状态流转统一收口。
- **收益**：解决了由于逻辑遗漏导致的“切换主模型时，新模型依然残留在备选链中，或旧模型凭空消失”的问题。

**2. 响应式渲染流统一：**
- 规范化数据变更后的渲染调用，确保底层 state 改变后统一触发 `renderProviders` 和 `renderDefaultBar`。
- **收益**：修复了原先在顶部设置主模型后，底部提供商卡片无法同步绿色高亮状态的 Bug。

**3. 优化防抖保存（`autoSave`）的生命周期：**
- **完善 `cleanup()` 卸载行为**：当组件被销毁前检查是否存在等待中的持久化任务（`_pendingSaveState`），如果有则立即落盘执行。
- **收益**：修复了用户在编辑配置后，如果于 300ms 防抖期内快速切换页面，会导致保存计时器被强制清空、修改未生效的隐蔽 Bug。