### PR TITLE
refactor(models): 重构主模型设置流程与同步渲染机制

### DIFF
--- a/src/pages/models.js
+++ b/src/pages/models.js
@@ -983,16 +983,23 @@ function setPrimary(state, full) {
 // 处理主模型变更后，备选链的数据流转
 function rotateFallbackChain(state, oldPrimary, newPrimary) {
   const modelConfig = ensureDefaultModelConfig(state)
-  const fallbacks = modelConfig.fallbacks || []
-  
+  const validModels = new Set(collectAllModels(state.config).map(m => m.full))
+  const seen = new Set()
+
   // 从备选链中移除新上位的主模型
-  const newFallbacks = fallbacks.filter(f => f !== newPrimary)
-  
+  const newFallbacks = (modelConfig.fallbacks || [])
+    .filter(f => f !== newPrimary && validModels.has(f))
+    .filter(f => {
+      if (seen.has(f)) return false
+      seen.add(f)
+      return true
+    })
+
   // 将原主模型降级放入备选链
-  if (oldPrimary) {
+  if (oldPrimary && oldPrimary !== newPrimary && validModels.has(oldPrimary) && !seen.has(oldPrimary)) {
     newFallbacks.push(oldPrimary)
   }
-  
+
   modelConfig.fallbacks = newFallbacks
 }
 

--- a/src/pages/models.js
+++ b/src/pages/models.js
@@ -116,7 +116,7 @@ function collectAllModels(config) {
       if (id) result.push({ provider: pk, modelId: id, full: `${pk}/${id}` })
     }
   }
-  return resul
+  return result
 }
 
 function getApiTypeLabel(apiType) {
@@ -272,18 +272,10 @@ function bindWaterfallActions(page, state) {
   container.querySelectorAll('.btn-set-primary-from-fb').forEach(btn => {
     btn.onclick = () => {
       const full = btn.dataset.id
-      const oldPrimary = getCurrentPrimary(state.config)
-      const fallbacks = state.config.agents.defaults.model.fallbacks || []
-
       pushUndo(state)
-      // 1. 设置新主模型
       setPrimary(state, full)
-      // 2. 将旧主模型放入备选链（原位置或末尾）
-      const newFallbacks = fallbacks.filter(f => f !== full)
-      if (oldPrimary) newFallbacks.push(oldPrimary)
-      state.config.agents.defaults.model.fallbacks = newFallbacks
-
       renderDefaultBar(page, state)
+      renderProviders(page, state)
       updateUndoBtn(page, state)
       autoSave(state)
       toast(t('models.setAsPrimarySuccess', { model: full }), 'success')
@@ -976,9 +968,32 @@ async function handleAction(action, btn, card, section, providerKey, provider, p
   }
 }
 
-// 设置主模型(仅修改 state,不写入文件)
+// 设置主模型入口
 function setPrimary(state, full) {
+  const oldPrimary = getCurrentPrimary(state.config)
+  if (oldPrimary === full) return
+
+  // 1. 设置新主模型状态
   ensureDefaultModelConfig(state).primary = full
+
+  // 2. 轮转备选链状态
+  rotateFallbackChain(state, oldPrimary, full)
+}
+
+// 处理主模型变更后，备选链的数据流转
+function rotateFallbackChain(state, oldPrimary, newPrimary) {
+  const modelConfig = ensureDefaultModelConfig(state)
+  const fallbacks = modelConfig.fallbacks || []
+  
+  // 从备选链中移除新上位的主模型
+  const newFallbacks = fallbacks.filter(f => f !== newPrimary)
+  
+  // 将原主模型降级放入备选链
+  if (oldPrimary) {
+    newFallbacks.push(oldPrimary)
+  }
+  
+  modelConfig.fallbacks = newFallbacks
 }
 
 // 应用默认模型:primary + 其余自动成为备选


### PR DESCRIPTION
本次提交重构了模型管理页面的状态流转逻辑，以降低业务侵入性并提升UI同步的健壮性。

### 核心变更
**1. 状态流转机制重构与解耦：**
- **重构 `setPrimary` 函数**：将原来散落在特定 UI 按钮点击事件中的“备选链轮转”业务逻辑抽离，封装出独立的 `rotateFallbackChain` 处理流程。
- **入口归一化**：现在无论是从“系统主/备模型”模块，还是从“模型供应商”模块设置主模型，底层状态流转统一收口于 `setPrimary`。这不仅清除了多余的面条代码，更彻底解决了由于逻辑遗漏导致的数据污染（切换主模型时，旧模型凭空消失、新模型未能从备选链中剔除，进而导致页面重载时状态被修正机制复原的问题）。

**2. 响应式双向渲染同步：**
- 规范化数据变更后的渲染调用流程，确保底层 state 改变后统一、完整地触发 `renderProviders` 和 `renderDefaultBar`。
- **收益**：修复了原先在顶部设置主模型后，底部提供商卡片无法同步更新绿色高亮（当前主模型）视觉状态的 Bug。