### PR TITLE
fix: 修复批量测试模型时误触发 Gateway 重启的问题

### DIFF
--- a/src/lib/tauri-api.js
+++ b/src/lib/tauri-api.js
@@ -203,7 +203,7 @@ export const api = {
   getStatusSummary: () => cachedInvoke('get_status_summary', {}, 60000),
   readOpenclawConfig: () => cachedInvoke('read_openclaw_config'),
   calibrateOpenclawConfig: (mode = 'inherit') => { invalidate('read_openclaw_config', 'check_installation', 'list_backups', 'get_services_status', 'get_status_summary'); return invoke('calibrate_openclaw_config', { mode }).then(r => { _debouncedReloadGateway(); return r }) },
-  writeOpenclawConfig: (config) => { invalidate('read_openclaw_config'); return invoke('write_openclaw_config', { config }).then(r => { _debouncedReloadGateway(); return r }) },
+  writeOpenclawConfig: (config, opts = {}) => { invalidate('read_openclaw_config'); return invoke('write_openclaw_config', { config }).then(r => { if (opts.noReload !== true) _debouncedReloadGateway(); return r }) },
   readMcpConfig: () => cachedInvoke('read_mcp_config'),
   writeMcpConfig: (config) => { invalidate('read_mcp_config'); return invoke('write_mcp_config', { config }) },
   reloadGateway: () => invoke('reload_gateway'),

--- a/src/pages/models.js
+++ b/src/pages/models.js
@@ -702,7 +702,7 @@ async function saveConfigOnly(state) {
     const primary = getCurrentPrimary(state.config)
     if (primary) applyDefaultModel(state)
     normalizeProviderUrls(state.config)
-    await api.writeOpenclawConfig(state.config)
+    await api.writeOpenclawConfig(state.config, { noReload: true })
   } catch (e) {
     toast(t('models.saveFailed') + ': ' + e, 'error')
   }
@@ -713,7 +713,7 @@ async function doAutoSave(state) {
     const primary = getCurrentPrimary(state.config)
     if (primary) applyDefaultModel(state)
     normalizeProviderUrls(state.config)
-    await api.writeOpenclawConfig(state.config)
+    await api.writeOpenclawConfig(state.config, { noReload: true })
 
     // 配置已写入。使用 3s 防抖 + 单飞行锁排队重启，避免快速连续编辑触发多次重启。
     showRestartPendingToast()
@@ -1604,7 +1604,7 @@ async function handleBatchTest(section, state, providerKey) {
   }
 
   const aborted = ctrl.abort
-  autoSave(state)
+  saveConfigOnly(state)
   if (aborted) {
     toast(t('models.batchTestAborted', { ok, fail, skip: ids.length - ok - fail }), 'warning')
   } else {


### PR DESCRIPTION
## 问题描述

修复了在模型配置页面执行「批量测试」时，会意外触发 Gateway 重启并弹出「配置已保存，即将生效」提示的问题。

Fixes #271 

### 根本原因
1. `handleBatchTest()` 错误地调用了 `autoSave()`，而不是预期的 `saveConfigOnly()`.
2. 即使使用了 `saveConfigOnly()`, 底层的 `api.writeOpenclawConfig` 仍然内置了一个盲目的 3 秒防抖重启机制 (`_debouncedReloadGateway`)。这导致常规编辑实际上在并发触发两次重启请求（前端队列的 restart 和 底层的 reload）。

### 解决方案
1. **API 层解耦**: 在 `tauri-api.js` 的 `writeOpenclawConfig` 中增加了一个 `{ noReload: true }` 的豁免选项。如果不传，则维持原样（确保其他页面的隐式重启行为不被破坏）。
2. **Models 页面净化**: `saveConfigOnly` 和 `doAutoSave` 现在会显式传入 `{ noReload: true }`。这使得 Models 页面彻底屏蔽底层隐式重启，完全交由其专属的高级队列 (`gateway-restart-queue.js`) 接管。
3. **批量测试修复**: 将 `handleBatchTest` 中的调用更正为 `saveConfigOnly`。