### PR TITLE
docs: add AGENTS.md with Cloud Agent development instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,39 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### Overview
+
+ClawPanel is a cross-platform AI Agent management panel (Vanilla JS + Vite frontend, optional Rust/Tauri desktop backend). In Cloud Agent environments, only the **Web development mode** is relevant—no Rust/Tauri compilation is needed.
+
+### Running the development server
+
+```bash
+npm run dev
+```
+
+This starts Vite on port 1420 with a `dev-api.js` plugin that provides mock/real backend API endpoints. Open http://localhost:1420 in Chrome. The default password is pre-filled on the login screen (the panel stores passwords in `~/.openclaw/clawpanel.json`).
+
+### Running tests
+
+```bash
+node --test tests/*.test.js
+```
+
+Note: Test 30 (`buildSnapshot.isLatest works against KERNEL_TARGET`) has a pre-existing failure unrelated to environment setup.
+
+### Building
+
+```bash
+npm run build
+```
+
+Build output goes to `dist/`.
+
+### Key gotchas
+
+- The app uses `package-lock.json`; always use **npm** (not pnpm/yarn).
+- No ESLint or Prettier configured for JS; the CI only checks Rust formatting (`cargo fmt --check`) and Rust lint (`cargo clippy`).
+- OpenClaw Gateway (port 18789) is an optional external dependency. The panel UI loads fine without it but AI chat features will not function.
+- Rust/Tauri system deps (libwebkit2gtk, etc.) are only needed for `npm run tauri dev`/`npm run tauri build`. They are NOT needed for web-only development.
+- The Vite config reads `~/.openclaw/openclaw.json` at startup for the Gateway WebSocket proxy port. If the file doesn't exist, it defaults to port 18789.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 变更描述

Add `AGENTS.md` with Cursor Cloud Agent-specific development instructions, covering how to run the dev server, tests, and build in web-only mode (no Rust/Tauri needed).

## 变更类型

- [x] 文档更新 (docs)

## 测试清单

- [x] 本地运行 `npm run build` 前端构建通过
- [x] 所有现有测试通过 (44/45 — 1 pre-existing failure in `kernel.test.js`)
- [x] Vite dev server starts successfully on port 1420
- [x] UI renders correctly in browser (navigated multiple pages)

## 截图 (如涉及 UI 变更)

Dev server running with the app functional:

[ClawPanel login page](https://cursor.com/agents/bc-5967547d-ef83-411c-b94b-84c89bdf92e0/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fclawpanel_login_page.webp)
[ClawPanel assistant page](https://cursor.com/agents/bc-5967547d-ef83-411c-b94b-84c89bdf92e0/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fclawpanel_assistant_page.webp)
[ClawPanel about page](https://cursor.com/agents/bc-5967547d-ef83-411c-b94b-84c89bdf92e0/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fclawpanel_about_page.webp)

Demo video of the app running:

[clawpanel-dev-demo.mp4](https://cursor.com/agents/bc-5967547d-ef83-411c-b94b-84c89bdf92e0/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fclawpanel-dev-demo.mp4)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5967547d-ef83-411c-b94b-84c89bdf92e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5967547d-ef83-411c-b94b-84c89bdf92e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

